### PR TITLE
fixed team id override on edit

### DIFF
--- a/components/inline-editor.vue
+++ b/components/inline-editor.vue
@@ -198,6 +198,12 @@ export default {
         return []
       }
     },
+    teamId: {
+      type: Number,
+      default() {
+        return 1
+      }
+    },
     clients: {
       type: Array,
       default() {
@@ -221,7 +227,6 @@ export default {
     return {
       local: this.content,
       client: null,
-      team: 'da',
       includedLocations: [],
       locations: [],
       internal: null,
@@ -234,6 +239,13 @@ export default {
     }
   },
   computed: {
+    team() {
+      const map = {
+        1: 'da',
+        2: 'seo'
+      }
+      return map[this.teamId]
+    },
     isValid() {
       const category = this.local.annotationCategory.value
       return category !== 'None'
@@ -292,7 +304,7 @@ export default {
           annotationUser: this.local.user.value,
           clientUrn: this.local.client.urn,
           locationUrns: this.local.locations.map(l => l.urn),
-          teamId: this.team === 'da' ? 1 : 2
+          teamId: this.teamId
         })
         .then(() => {
           this.showGlobalAlert('Note Updated!', 'success')

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -350,6 +350,7 @@
                   :content="row.item"
                   :clients="clients"
                   :users="users"
+                  :teamId="row.item.team.id"
                   :categories="categories"
                   :action-types="actionTypes"
                   @on-close="row.toggleDetails()"


### PR DESCRIPTION
Updated inline editor to take a team ID as a prop that is used on the post in the save method. Added computed team property to dynamically change the category and action type drop downs based on team. This was previously hard coded to da so the seo team could not update the category types to the associated seo category/action types.